### PR TITLE
[Refinement] Slack User IDs moved to ENV

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,7 +1,4 @@
 ---
-slack-users:
-  USA3Y6NAY: che
-  U01P7UHM2MV: oh
 commands:
   postgres: deploy-postgresql-service
   logme: deploy-logme-service


### PR DESCRIPTION
Slack User IDs will be read from environment due to convenience.
(E.g. new or leaving employees don't need a new final)